### PR TITLE
Fix -Wreorder flagging

### DIFF
--- a/include/boost/cobalt/detail/generator.hpp
+++ b/include/boost/cobalt/detail/generator.hpp
@@ -95,9 +95,9 @@ struct generator_receiver : generator_receiver_base<Yield, Push>
   generator_receiver() = default;
   generator_receiver(generator_receiver && lhs)
   : generator_receiver_base<Yield, Push>{std::move(lhs.pushed_value)},
-    exception(std::move(lhs.exception)), done(lhs.done),
+    exception(std::move(lhs.exception)),
     result(std::move(lhs.result)),
-    result_buffer(std::move(lhs.result_buffer)),
+    result_buffer(std::move(lhs.result_buffer)), done(lhs.done),
     awaited_from(std::move(lhs.awaited_from)), yield_from{std::move(lhs.yield_from)},
     lazy(lhs.lazy), reference(lhs.reference), cancel_signal(lhs.cancel_signal)
 


### PR DESCRIPTION
If using -Werror=reorder via some cmake build or otherwise, this gets flagged.

Might want to `-Wall -Wextra -Werror` or more in the cmake as well? I'd do it myself but I don't follow the whole "duplicate the lib in the `BOOST_COBALT_IS_ROOT`" case and/or where to move the copyright notice. Also don't know any policies regarding how to set those flags as part of a boost project.