### PR TITLE
Install boost_cobalt_io_ssl by default

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -39,6 +39,6 @@ explicit
     ;
 
 call-if : boost-library cobalt
-        : install boost_cobalt boost_cobalt_io
+        : install boost_cobalt boost_cobalt_io boost_cobalt_io_ssl
     ;
 


### PR DESCRIPTION
Make sure boost_cobalt_io_ssl library is built and installed by default when Boost as a whole or Boost.Cobalt is built (i.e. when the user runs b2 in libs/cobalt).