### PR TITLE
Avoid ODR violations by using fixed types for protocol constants

### DIFF
--- a/include/boost/cobalt/io/endpoint.hpp
+++ b/include/boost/cobalt/io/endpoint.hpp
@@ -50,9 +50,9 @@ struct stream_socket;
 
 struct protocol_type
 {
-  using family_t   = decltype(BOOST_ASIO_OS_DEF(AF_INET));
-  using type_t     = decltype(BOOST_ASIO_OS_DEF(SOCK_STREAM));
-  using protocol_t = decltype(BOOST_ASIO_OS_DEF(IPPROTO_TCP));
+  using family_t   = int;
+  using type_t     = int;
+  using protocol_t = int;
 
   constexpr family_t     family() const noexcept {return family_;};
   constexpr type_t         type() const noexcept {return type_;};
@@ -90,9 +90,9 @@ struct protocol_type
   protocol_t protocol_ = static_cast<protocol_t>(0);
 };
 
-template<auto Family   = static_cast<protocol_type::family_t>(0),
-         auto Type     = static_cast<protocol_type::type_t>(0),
-         auto Protocol = static_cast<protocol_type::protocol_t>(0)>
+template<protocol_type::family_t Family     = static_cast<protocol_type::family_t>(0),
+         protocol_type::type_t Type         = static_cast<protocol_type::type_t>(0),
+         protocol_type::protocol_t Protocol = static_cast<protocol_type::protocol_t>(0)>
 struct static_protocol
 {
   using family_t   = protocol_type::family_t  ;


### PR DESCRIPTION
At least on Linux, constants such as `AF_INET`, `SOCK_STREAM` and `IPPROTO_TCP` are implemented with unnamed enums, which makes these constants have different types in different translation units. This results in ODR violations as `protocol_type` struct ends up defined differently in every TU.

Also, `static_protocol` that is being instantiated with these constants also produces different types in each TU. While this by itself is not an ODR violation, it may generate lots of code and data duplication.

Avoid all of the above by using fixed types for family, type and protocol constants in `protocol_type` and `static_protocol`. Use `int` for each of the types, following POSIX socket(2) signature.

Fixes https://github.com/boostorg/cobalt/issues/242.