### PR TITLE
CMake: Fixup stand-alone build to not depend on removed system stub library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,10 +175,11 @@ else()
     if (NOT BOOST_COBALT_BUILD_INLINE)
         find_package(Threads REQUIRED)
         # Boost 1.82 is the first with a Boost.ASIO with necessary support
-        find_package(Boost REQUIRED COMPONENTS system OPTIONAL_COMPONENTS json context url unit_test_framework)
+        find_package(Boost OPTIONAL_COMPONENTS json context url unit_test_framework)
         if (BOOST_COBALT_USE_BOOST_CONTAINER)
             find_package(Boost REQUIRED container)
         endif()
+        include_directories(${Boost_INCLUDE_DIR})
     endif()
 
     add_library(boost_cobalt
@@ -192,7 +193,6 @@ else()
 
     target_include_directories(boost_cobalt PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
     target_link_libraries(boost_cobalt PUBLIC
-            Boost::system
             Threads::Threads)
     target_compile_definitions(boost_cobalt PRIVATE BOOST_COBALT_SOURCE=1 )
 


### PR DESCRIPTION
I had trouble building cobalt stand-alone using system-installed boost 1.89.0, apparently due to the 
[removal of Boost::system](https://github.com/boostorg/system/issues/132).  This changes uses the `Boost_INCLUDE_DIR` variable instead.

Without this change:

```
$ CMAKE_PREFIX_PATH=/opt cmake .. -G Ninja -DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_BUILD_TYPE=Debug
CMake Error at /opt/boost-1.89.0/lib/cmake/Boost-1.89.0/BoostConfig.cmake:141 (find_package):
  Could not find a package configuration file provided by "boost_system"
  (requested version 1.89.0) with any of the following names:

    boost_systemConfig.cmake
    boost_system-config.cmake

  Add the installation prefix of "boost_system" to CMAKE_PREFIX_PATH or set
  "boost_system_DIR" to a directory containing one of the above files.  If
  "boost_system" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  /opt/boost-1.89.0/lib/cmake/Boost-1.89.0/BoostConfig.cmake:262 (boost_find_component)
  /usr/share/cmake-3.28/Modules/FindBoost.cmake:594 (find_package)
  CMakeLists.txt:178 (find_package)
  ```