### PR TITLE
doc: fixed typos

### DIFF
--- a/doc/background/custom_executors.adoc
+++ b/doc/background/custom_executors.adoc
@@ -1,11 +1,11 @@
 == Custom Executors
 
-One of the reasons cobalt defaults to https://www.boost.org/doc/libs/master/doc/html/boost_asio/reference/any_io_executor.html::[`asio::any_io_executor`]
+One of the reasons cobalt defaults to https://www.boost.org/doc/libs/master/doc/html/boost_asio/reference/any_io_executor.html[`asio::any_io_executor`]
 is that it is a type-erased executor, i.e. you can provide your own event-loop without needing to recompile `cobalt`.
 
 However, during the development of the Executor TS, the executor concepts got a bit unintuitive, to put it mildly.
 
-Ruben Perez wrote an excellent https://anarthal.github.io/cppblog/asio-props.html::[blog post], which I am shamelessly going to draw from.
+Ruben Perez wrote an excellent https://anarthal.github.io/cppblog/asio-props.html[blog post], which I am shamelessly going to draw from.
 
 === Definition
 

--- a/doc/reference/io/write.adoc
+++ b/doc/reference/io/write.adoc
@@ -1,4 +1,4 @@
-== cobalt/io/read.hpp
+== cobalt/io/write.hpp
 
 The `write` and `write_at` write the full buffer to a stream.
 


### PR DESCRIPTION
* https://www.boost.org/doc/libs/latest/libs/cobalt/doc/html/index.html#cobaltioread_hpp

    <details><summary>Section title duplicate</summary>
    <img width="700" alt="image" src="https://github.com/user-attachments/assets/7b399405-d8d4-465e-ba1c-8907ebe9b123" />
    </details>

* https://www.boost.org/doc/libs/latest/libs/cobalt/doc/html/index.html#custom_executors

    <details><summary>Broken links</summary>
    <img width="700" alt="image" src="https://github.com/user-attachments/assets/ae995f4e-aacb-4461-8ee4-2a8258ea279e" />
    </details>




