### PR TITLE
Fix typo in compiler.adoc

### DIFF
--- a/doc/compiler.adoc
+++ b/doc/compiler.adoc
@@ -2,7 +2,7 @@
 
 == Libraries
 
-Boost.cobalt requires a C++20 compilers and directly depends on the following boost libraries:
+Boost.cobalt requires a C++20 compiler and directly depends on the following boost libraries:
 
 - boost.asio
 - boost.system
@@ -14,12 +14,12 @@ Boost.cobalt requires a C++20 compilers and directly depends on the following bo
 
 == Compiler
 
-This library is supported since Clang 14, Gcc 10 & MSVC 19.30 (Visual Studio 2022).
+This library is supported since Clang 14, GCC 10 & MSVC 19.30 (Visual Studio 2022).
 
-IMPORTANT: Gcc versions 12.1 and 12.2 appear to have a bug for coroutines with out stack variables
+IMPORTANT: GCC versions 12.1 and 12.2 appear to have a bug for coroutines with out stack variables
 as can be seen [here](https://godbolt.org/z/6adGcqP1z) and should be avoided for coroutines.
 
-Clang only added `std::pmr` support in 16, so older clang versions use `boost::container::pmr` as a drop-in replacement.
+Clang only added `std::pmr` support in 16, so older Clang versions use `boost::container::pmr` as a drop-in replacement.
 
 WARNING: Some if not all MSVC versions have a broken coroutine implementation,
 that this library needs to workaround. This may cause non-deterministic behaviour and overhead.


### PR DESCRIPTION
Also use correct capitalization for GCC and Clang