### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -51,7 +51,6 @@ deps = [
     'libs/ratio',
     'libs/regex',
     'libs/smart_ptr',
-    'libs/static_assert',
     'libs/static_string',
     'libs/system',
     'libs/test',


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.